### PR TITLE
Implemented an optimization in SSIM.ssim_value.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,3 +5,4 @@
 * Jeff Terrace, jterrace@gmail.com
 * Wieland Morgenstern
 * Gabriele Lami, koteth@gmail.com 
+* Martin McGreal, CTY, martin@cty.io, http://cty.io

--- a/ssim/ssimlib.py
+++ b/ssim/ssimlib.py
@@ -82,7 +82,7 @@ class SSIM(object):
         """
         # Performance boost if handed a compatible SSIMImage object.
         if not isinstance(target, SSIMImage) \
-          or not np.array_equal(self.gaussian_kernel_1d, target.gaussian_kernel_1d):
+          or not numpy.array_equal(self.gaussian_kernel_1d, target.gaussian_kernel_1d):
             target = SSIMImage(target, self.gaussian_kernel_1d, self.img1.size)
 
         img_mat_12 = self.img1.img_gray * target.img_gray

--- a/ssim/ssimlib.py
+++ b/ssim/ssimlib.py
@@ -69,24 +69,26 @@ class SSIM(object):
         self.gaussian_kernel_1d = gaussian_kernel_1d
         self.img1 = SSIMImage(img1, gaussian_kernel_1d)
 
-    def ssim_value(self, img2):
-        """Compute the SSIM value from the reference image to the given image.
+    def ssim_value(self, target):
+        """Compute the SSIM value from the reference image to the target image.
 
         Args:
-          img2: Input image to compare the reference image to.
+          target: Input image to compare the reference image to. This may be a
+          PIL Image object or, to save time, an SSIMImage object (e.g. the img1
+          member of another SSIM object).
 
         Returns:
           Computed SSIM float value.
         """
         # Performance boost if handed a compatible SSIMImage object.
-        if not isinstance(img2, SSIMImage) \
-          or not (self.gaussian_kernel_1d == img2.gaussian_kernel_1d).all():
-            img2 = SSIMImage(img2, self.gaussian_kernel_1d, self.img1.size)
+        if not isinstance(target, SSIMImage) \
+          or not np.array_equal(self.gaussian_kernel_1d, target.gaussian_kernel_1d):
+            target = SSIMImage(target, self.gaussian_kernel_1d, self.img1.size)
 
-        img_mat_12 = self.img1.img_gray * img2.img_gray
+        img_mat_12 = self.img1.img_gray * target.img_gray
         img_mat_sigma_12 = convolve_gaussian_2d(
             img_mat_12, self.gaussian_kernel_1d)
-        img_mat_mu_12 = self.img1.img_gray_mu * img2.img_gray_mu
+        img_mat_mu_12 = self.img1.img_gray_mu * target.img_gray_mu
         img_mat_sigma_12 = img_mat_sigma_12 - img_mat_mu_12
 
         # Numerator of SSIM
@@ -95,10 +97,10 @@ class SSIM(object):
 
         # Denominator of SSIM
         den_ssim = (
-            (self.img1.img_gray_mu_squared + img2.img_gray_mu_squared +
+            (self.img1.img_gray_mu_squared + target.img_gray_mu_squared +
              self.c_1) *
             (self.img1.img_gray_sigma_squared +
-             img2.img_gray_sigma_squared + self.c_2))
+             target.img_gray_sigma_squared + self.c_2))
 
         ssim_map = num_ssim / den_ssim
         index = numpy.average(ssim_map)

--- a/ssim/ssimlib.py
+++ b/ssim/ssimlib.py
@@ -6,7 +6,7 @@ import argparse
 import glob
 import sys
 
-import numpy
+import numpy as np
 
 from ssim import compat
 from ssim.utils import convolve_gaussian_2d
@@ -82,7 +82,8 @@ class SSIM(object):
         """
         # Performance boost if handed a compatible SSIMImage object.
         if not isinstance(target, SSIMImage) \
-          or not numpy.array_equal(self.gaussian_kernel_1d, target.gaussian_kernel_1d):
+          or not np.array_equal(self.gaussian_kernel_1d,
+                                target.gaussian_kernel_1d):
             target = SSIMImage(target, self.gaussian_kernel_1d, self.img1.size)
 
         img_mat_12 = self.img1.img_gray * target.img_gray
@@ -103,7 +104,7 @@ class SSIM(object):
              target.img_gray_sigma_squared + self.c_2))
 
         ssim_map = num_ssim / den_ssim
-        index = numpy.average(ssim_map)
+        index = np.average(ssim_map)
         return index
 
 def main():

--- a/ssim/ssimlib.py
+++ b/ssim/ssimlib.py
@@ -78,7 +78,11 @@ class SSIM(object):
         Returns:
           Computed SSIM float value.
         """
-        img2 = SSIMImage(img2, self.gaussian_kernel_1d, self.img1.size)
+        # Performance boost if handed a compatible SSIMImage object.
+        if not isinstance(img2, SSIMImage) \
+          or not (self.gaussian_kernel_1d == img2.gaussian_kernel_1d).all():
+            img2 = SSIMImage(img2, self.gaussian_kernel_1d, self.img1.size)
+
         img_mat_12 = self.img1.img_gray * img2.img_gray
         img_mat_sigma_12 = convolve_gaussian_2d(
             img_mat_12, self.gaussian_kernel_1d)


### PR DESCRIPTION
When comparing many images against many other images, it can save a lot of
time to cache SSIM objects.  With that in mind I've modified the
SSIM.ssim_value() method to recognize when it is passed an SSIM object rather
than a regular PIL Image object, and in that case skip the process of building
a new SSIM object for it.  Now to compare an image to another one that already
has an SSIM object created for it, we just pass the img1 member of the second
SSIM object to the ssim_value method of the first SSIM object.

The code makes sure that not only is the object passed into ssim_value an SSIM object, but also that the kernel used to create it is the same as the current object.