### PR TITLE
Normalize gaussian kernel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
 script:
  - pyssim test-images/test1-1.png test-images/test1-1.png | grep 1
  - pyssim test-images/test1-1.png test-images/test1-2.png | grep 0.998
- - pyssim test-images/test1-1.png "test-images/*" | grep -E " 1| 0.998| 0.673| 0.648" | wc -l | grep 4
+ - pyssim test-images/test1-1.png "test-images/*" | grep -E " 1| 0.998| 0.672| 0.648" | wc -l | grep 4
  - pyssim --cw --width 128 --height 128 test-images/test1-1.png test-images/test1-1.png | grep 1
  - pyssim --cw --width 128 --height 128 test-images/test3-orig.jpg test-images/test3-rot.jpg | grep 0.938
  - pylint --rcfile=.pylintrc setup.py

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ To test:
 
     $ PYTHONPATH="." python ssim test-images/test1-1.png "test-images/*"
     test-images/test1-1.png - test-images/test1-1.png: 1
-    test-images/test1-1.png - test-images/test1-2.png: 0.9981071
-    test-images/test1-1.png - test-images/test2-1.png: 0.67301
-    test-images/test1-1.png - test-images/test2-2.png: 0.6488112
+    test-images/test1-1.png - test-images/test1-2.png: 0.9980119
+    test-images/test1-1.png - test-images/test2-1.png: 0.6726952
+    test-images/test1-1.png - test-images/test2-2.png: 0.6485879
 
 ## References
 

--- a/ssim/utils.py
+++ b/ssim/utils.py
@@ -4,9 +4,7 @@ from __future__ import absolute_import
 
 import numpy
 from numpy.ma.core import exp
-from numpy.ma.core import sqrt
 import scipy.ndimage
-from scipy.constants.constants import pi
 
 from ssim.compat import ImageOps
 
@@ -26,10 +24,9 @@ def get_gaussian_kernel(gaussian_kernel_width=11, gaussian_kernel_sigma=1.5):
 
     # Fill Gaussian kernel
     for i in range(gaussian_kernel_width):
-        gaussian_kernel_1d[i] = (
-            (1 / (sqrt(2 * pi) * (gaussian_kernel_sigma))) *
-            exp(-(((i - norm_mu) ** 2)) / (2 * (gaussian_kernel_sigma ** 2))))
-    return gaussian_kernel_1d
+        gaussian_kernel_1d[i] = (exp(-(((i - norm_mu) ** 2)) /
+                                     (2 * (gaussian_kernel_sigma ** 2))))
+    return gaussian_kernel_1d / numpy.sum(gaussian_kernel_1d)
 
 def to_grayscale(img):
     """Convert PIL image to numpy grayscale array and numpy alpha array.


### PR DESCRIPTION
Resolves #9.

The discrete gaussian kernel created in this helper function does
not perfectly sum up to 1. Especially when sigma < 1, the sum of
the kernel will be larger than 1, at around 1.01.

Trying to compute the variance with the algebraic formula creates
a second term that is larger than the first term with a kernel
like this. The variance becomes negative, and the computed SSIM
overflows.

--

Pylint checked.

The SSIM computed for the images reported in issue #9 is now always below 1.

The results of the tests are now slightly different:

test-images/test1-1.png - test-images/test1-1.png: 1
test-images/test1-1.png - test-images/test1-2.png: 0.9980119
test-images/test1-1.png - test-images/test2-1.png: 0.6726952
test-images/test1-1.png - test-images/test2-2.png: 0.6485879
test-images/test1-1.png - test-images/test3-cro.jpg: 0.2306724
test-images/test1-1.png - test-images/test3-lig.jpg: 0.2919399
test-images/test1-1.png - test-images/test3-orig.jpg: 0.2276495
test-images/test1-1.png - test-images/test3-rot.jpg: 0.2387026

I'm not sure there is any single reference implementation these values should be checked against? Or a test set of images? Trying to compare with the implementation in scikit-image yields very different results already in the current implementation.