### PR TITLE
Add timing code for SSIM and CW-SSIM

### DIFF
--- a/SSIM_CW-SSIM_comparison.ipynb
+++ b/SSIM_CW-SSIM_comparison.ipynb
@@ -9,6 +9,7 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
+    "import time\n",
     "import numpy as np\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
@@ -198,13 +199,16 @@
     }
    ],
    "source": [
+    "start = time.time()\n",
     "ssim_rot = SSIM(im, gaussian_kernel_1d).ssim_value(im_rot)\n",
     "ssim_lig = SSIM(im, gaussian_kernel_1d).ssim_value(im_lig)\n",
     "ssim_cro = SSIM(im, gaussian_kernel_1d).ssim_value(im_cro)\n",
+    "end = time.time()\n",
     "\n",
     "print(\"SSIM of rotated image %.4f\" % ssim_rot)\n",
     "print(\"SSIM of modified lighting image %.4f\" % ssim_lig)\n",
-    "print(\"SSIM of cropped image %.4f\" % ssim_cro)"
+    "print(\"SSIM of cropped image %.4f\" % ssim_cro)\n",
+    "print(\"Elapsed time of SSIM is %.6fs\" % (end - start))"
    ]
   },
   {
@@ -225,13 +229,16 @@
     }
    ],
    "source": [
+    "start = time.time()\n",
     "cw_ssim_rot = SSIM(im).cw_ssim_value(im_rot)\n",
     "cw_ssim_lig = SSIM(im).cw_ssim_value(im_lig)\n",
     "cw_ssim_cro = SSIM(im).cw_ssim_value(im_cro)\n",
+    "end = time.time()\n",
     "\n",
     "print(\"CW-SSIM of rotated image %.4f\" % cw_ssim_rot)\n",
     "print(\"CW-SSIM of modified lighting image %.4f\" % cw_ssim_lig)\n",
-    "print(\"CW-SSIM of cropped image %.4f\" % cw_ssim_cro)"
+    "print(\"CW-SSIM of cropped image %.4f\" % cw_ssim_cro)\n",
+    "print(\"Elapsed time of CW-SSIM is %.6fs\" % (end - start))"
    ]
   }
  ],


### PR DESCRIPTION
People trying CW-SSIM may consider the elapsed time compared with the original SSIM, so IMHO adding timing code for both algorithms may be beneficial.