### PR TITLE
Replace Image.ANTIALIAS with Image.LANCZOS

### DIFF
--- a/SSIM_CW-SSIM_comparison.ipynb
+++ b/SSIM_CW-SSIM_comparison.ipynb
@@ -34,19 +34,19 @@
     "size = (256,256)\n",
     "\n",
     "im = Image.open('test-images/test3-orig.jpg')\n",
-    "im = im.resize(size, Image.ANTIALIAS)\n",
+    "im = im.resize(size, Image.LANCZOS)\n",
     "\n",
     "# slightly rotated image\n",
     "im_rot = Image.open('test-images/test3-rot.jpg')\n",
-    "im_rot = im_rot.resize(size, Image.ANTIALIAS)\n",
+    "im_rot = im_rot.resize(size, Image.LANCZOS)\n",
     "\n",
     "# slightly modified lighting conditions\n",
     "im_lig = Image.open('test-images/test3-lig.jpg')\n",
-    "im_lig = im_lig.resize(size, Image.ANTIALIAS)\n",
+    "im_lig = im_lig.resize(size, Image.LANCZOS)\n",
     "\n",
     "# image cropped\n",
     "im_cro = Image.open('test-images/test3-cro.jpg')\n",
-    "im_cro = im_cro.resize(size, Image.ANTIALIAS)"
+    "im_cro = im_cro.resize(size, Image.LANCZOS)"
    ]
   },
   {

--- a/ssim/ssimlib.py
+++ b/ssim/ssimlib.py
@@ -45,7 +45,7 @@ class SSIMImage(object):
         # Resize image if size is defined and different
         # from original image
         if size and size != self.img.size:
-            self.img = self.img.resize(size, Image.ANTIALIAS)
+            self.img = self.img.resize(size, Image.LANCZOS)
 
         # Set the size of the image
         self.size = self.img.size


### PR DESCRIPTION
This adds compatibility with Pillow 10, when ANTIALIAS was removed. Meanwhile, LANCZOS has been an alias since Pillow 2.7.0.